### PR TITLE
WIP: Pjax navigation

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -2,4 +2,5 @@ import "../css/main.scss"
 import "bootstrap"
 
 import "./lazyload"
+import "./navigation"
 import "@/partners/assets/js/partners.js"

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -1,0 +1,63 @@
+const Pjax = require('pjax')
+const on = require('pjax/lib/events/on')
+const trigger = require('pjax/lib/events/trigger')
+const clone = require('pjax/lib/util/clone')
+
+
+const PAGE_CACHE = {}
+
+/**
+ * We override Pjax's loadUrl function so that requests for the same href are
+ * cached.
+ * Warning! This implementation is guaranteed to work only for simple cases
+ * where only GET requests are made, no options are passed, etc.
+ */
+Pjax.prototype._noCacheHandleResponse = Pjax.prototype.handleResponse
+Pjax.prototype._noCacheLoadUrl = Pjax.prototype.loadUrl
+Pjax.prototype.handleResponse = function (responseText, request, href, options) {
+  Pjax.prototype._noCacheHandleResponse.bind(this)(responseText, request, href, options)
+  PAGE_CACHE[href] = responseText
+}
+Pjax.prototype.loadUrl = function (href, options) {
+  if (PAGE_CACHE.hasOwnProperty(href)) {
+    const responseText = PAGE_CACHE[href]
+    this.state.href = href
+    this.state.options = options
+    try {
+      this.loadContent(responseText, options)
+    } catch (e) {
+      trigger(document, 'pjax:error', options)
+      return this.latestChance(href)
+    }
+  } else {
+    this._noCacheLoadUrl(href, options)
+  }
+}
+Pjax.prototype.prefetchUrl = function (href, options) {
+  // Skip if already prefetched
+  if (PAGE_CACHE.hasOwnProperty(href)) return
+
+  this.doRequest(href, options, function (responseText, request, href, options) {
+    PAGE_CACHE[href] = responseText
+  })
+}
+
+// Override Pjax's parseDOM to prefetch when user hovers a link
+Pjax.prototype._noHoverAttachLink = Pjax.prototype.attachLink
+Pjax.prototype.attachLink = function (el) {
+  this._noHoverAttachLink(el)
+  on(el, 'mouseenter', event => {
+    const options = clone(this.options)
+    options.triggerElement = el
+    this.prefetchUrl(el.href, options)
+  })
+}
+
+const pjax = new Pjax({
+  selectors: [
+    'title',
+    'meta[name=description]',
+    '#main',
+  ],
+  cacheBust: false,
+})

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -6,6 +6,49 @@ const clone = require('pjax/lib/util/clone')
 
 const PAGE_CACHE = {}
 
+/* Detect fast connections to enable prefetches
+ *
+ * Adapted from:
+ * https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API
+ */
+let SHOULD_PREFETCH = false
+let conn = navigator.connection || navigator.mozConnection || navigator.webkitConnection
+if (conn && (conn.effectiveType == '3g' || conn.effectiveType == '4g')) {
+  SHOULD_PREFETCH = true
+}
+
+/**
+ * Checks if link of given element is to a page with the same language as the
+ * current one.
+ *
+ * @param {Anchor} el Anchor tag.
+ * @returns {boolean} True if language is the same.
+ */
+function isSameLang (el) {
+  return (
+    el.pathname.substring(0, 4) === window.location.pathname.substring(0, 4)
+  )
+}
+
+/**
+ * Adapted from:
+ * https://github.com/MoOx/pjax/blob/480334b18253c721ba648675e90261f948e2bca0/lib/proto/attach-link.js
+ */
+function checkIfShouldAbort (el) {
+  return (
+    // Is external link?
+    el.protocol !== window.location.protocol ||
+    el.host !== window.location.host ||
+    // Is anchor on the same page?
+    (el.hash &&
+      el.href.replace(el.hash, "") ===
+        window.location.href.replace(location.hash, "")
+    ) ||
+    el.href === window.location.href.split("#")[0] + "#" ||
+    !isSameLang(el)
+  )
+}
+
 /**
  * We override Pjax's loadUrl function so that requests for the same href are
  * cached.
@@ -33,30 +76,43 @@ Pjax.prototype.loadUrl = function (href, options) {
     this._noCacheLoadUrl(href, options)
   }
 }
-Pjax.prototype.prefetchUrl = function (href, options) {
-  // Skip if already prefetched
-  if (PAGE_CACHE.hasOwnProperty(href)) return
+Pjax.prototype.prefetchUrl = function (el, options) {
+  // Skip if already prefetched or should abort
+  if (PAGE_CACHE.hasOwnProperty(el.href) || checkIfShouldAbort(el)) {
+    return
+  }
 
-  this.doRequest(href, options, function (responseText, request, href, options) {
-    PAGE_CACHE[href] = responseText
-  })
+  this.doRequest(
+    el.href,
+    options,
+    function (responseText, request, href, options) {
+      PAGE_CACHE[el.href] = responseText
+    },
+  )
 }
 
-// Override Pjax's parseDOM to prefetch when user hovers a link
+// Override Pjax's attachLink to handle other language and prefetches
 Pjax.prototype._noHoverAttachLink = Pjax.prototype.attachLink
 Pjax.prototype.attachLink = function (el) {
+  // Don't attach if its a link to other language version
+  if (!isSameLang(el)) return
+
   this._noHoverAttachLink(el)
-  on(el, 'mouseenter', event => {
-    const options = clone(this.options)
-    options.triggerElement = el
-    this.prefetchUrl(el.href, options)
-  })
+  if (SHOULD_PREFETCH) {
+    on(el, 'mouseenter', event => {
+      const options = clone(this.options)
+      options.triggerElement = el
+      this.prefetchUrl(el, options)
+    })
+  }
 }
 
-const pjax = new Pjax({
+// Create and expose
+window.pjax = new Pjax({
   selectors: [
     'title',
     'meta[name=description]',
+    'meta[property="og:image"]',
     '#main',
   ],
   cacheBust: false,

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -116,4 +116,9 @@ window.pjax = new Pjax({
     '#main',
   ],
   cacheBust: false,
+  analytics: function () {
+    if (window._paq) {
+      window._paq.push(['trackPageView'])
+    }
+  }
 })

--- a/bundles/package-lock.json
+++ b/bundles/package-lock.json
@@ -4932,6 +4932,11 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pjax": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/pjax/-/pjax-0.2.8.tgz",
+      "integrity": "sha512-IeVXXIZJzxVDYzV2Td5MZkWJcny8JRCz2dQ1xxhIUbIFgP+08ymV7WXVtbF8NlUd2MZKH1cNvhuTOd2QAOGcOg=="
+    },
     "pkg-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",

--- a/bundles/package.json
+++ b/bundles/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "bootstrap": "^4.3.1",
     "jquery": "^3.4.0",
+    "pjax": "^0.2.8",
     "popper.js": "^1.14.7"
   }
 }

--- a/project/home/assets/js/checkerboardView.js
+++ b/project/home/assets/js/checkerboardView.js
@@ -39,6 +39,10 @@ function createCheckerboardView(tabEl, layout) {
       let elIdx = layout[i][j]
       if (elIdx >= 0 && elIdx < simpleView.children.length) {
         let clone = simpleView.children[elIdx].cloneNode(true)
+        // Attach pjax listeners
+        if (window.pjax) {
+          window.pjax.attachLink(clone)
+        }
         checkerboardView.appendChild(clone)
       } else {
         checkerboardView.appendChild(createSpacer())

--- a/project/templates/layouts/partials/nav.html
+++ b/project/templates/layouts/partials/nav.html
@@ -31,8 +31,8 @@
         </li>
         <li class="nav-item dropdown">
             <a role="menuitem" class="nav-link dropdown-toggle"
-                href="{% url 'speakers' %}" data-toggle="dropdown"
-                aria-haspopup="true" aria-expanded="false">
+                href="#" data-toggle="dropdown" aria-haspopup="true"
+                aria-expanded="false">
                 <div class="nav-link-icon triangles blue-black"
                     aria-hidden="true"></div>
                 <span class="nav-item-text">


### PR DESCRIPTION
Resolves #25

- [x] Prefetch on hover functionality
- [x] Disable prefetch on metered connections (see [netinfo API](https://wicg.github.io/netinfo/))?
- [ ] Strategy for which pages to prefetch when
- [x] Other headers that need update (e.g. [Facebook Open Graph tags](https://developers.facebook.com/docs/sharing/webmasters/))